### PR TITLE
Close NamedTemporaryFile early for Windows compat

### DIFF
--- a/webassets_elm/__init__.py
+++ b/webassets_elm/__init__.py
@@ -1,3 +1,4 @@
+import os
 from sys import platform
 from tempfile import NamedTemporaryFile, TemporaryFile
 from webassets.filter import ExternalTool
@@ -31,7 +32,10 @@ class Elm(ExternalTool):
         """
 
         # write to a temp file
-        tmp = NamedTemporaryFile(suffix='.js', delete=True)
+        tmp = NamedTemporaryFile(suffix='.js', delete=False)
+        # if we don't close here, elm-make won't be able to access the file
+        # on Windows
+        tmp.close()
         elm_make = self.binary or 'elm-make'
         source = kw['source_path']
         write_args = [elm_make, source, '--output', tmp.name, '--yes']
@@ -42,4 +46,4 @@ class Elm(ExternalTool):
         cat_or_type = 'type' if platform == 'win32' else 'cat'
         read_args = [cat_or_type, tmp.name]
         self.subprocess(read_args, out)
-        tmp.close()
+        os.remove(tmp.name)


### PR DESCRIPTION
Hi. Running `python manage.py assets build` or `watch` causes the following error on Windows:

```
webassets.exceptions.FilterError: elm: subprocess returned a non-success result code: 1,
stdout=b'Success! Compiled 0 modules.\r\n',
stderr=b'elm-make: C:\\Users\\Zimmermann\\AppData\\Local\\Temp\\tmph2k6lcv_.js: openFile: permission denied (Permission denied)\n'
```

The problem comes from Python's `tempfile.NamedTemporaryFile`. As long as the file is not closed in Python, it can't be accessed by external processes on Windows. You can read about that here:

https://bugs.python.org/issue14243

and in the `tempfile` documentation:

https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile

The solution is just to create the temp file with `detete=False`, close it immediately, and delete it manually when it's not used anymore. `webassets.filter.ExternalTool.subprocess` itself uses a similar approach, only with `tempfile.mkstemp` instead.

