### PR TITLE
Run elm-package install before elm-make

### DIFF
--- a/webassets_elm/__init__.py
+++ b/webassets_elm/__init__.py
@@ -17,10 +17,17 @@ class Elm(ExternalTool):
         The path to the ``elm-make`` binary. If not set, assumes ``elm-make``
         is in the system path.
 
+    ELM_PACKAGE_BIN
+        The path to the ``elm-package`` binary. If not set, assumes
+        ``elm-package`` is in the system path.
+
     """
 
     name = 'elm'
-    options = {'binary': 'ELM_MAKE_BIN'}
+    options = {
+        'elm_make_binary': 'ELM_MAKE_BIN',
+        'elm_package_binary': 'ELM_PACKAGE_BIN',
+    }
     max_debug_level = None
 
     def input(self, _in, out, **kw):
@@ -31,12 +38,19 @@ class Elm(ExternalTool):
         output to stdout.
         """
 
+        # first install/update elm-package dependencies
+        elm_package = self.elm_package_binary or 'elm-package'
+        install_args = [elm_package, 'install', '--yes']
+        # set utf-8 to handle unicode bullet point symbols
+        with TemporaryFile(mode='w', encoding='utf-8') as fake_write_obj:
+            self.subprocess(install_args, fake_write_obj)
+
         # create a temp file
         tmp = NamedTemporaryFile(suffix='.js', delete=False)
         tmp.close()  # close it so windows can read it
 
         # write to a temp file
-        elm_make = self.binary or 'elm-make'
+        elm_make = self.elm_make_binary or 'elm-make'
         source = kw['source_path']
         write_args = [elm_make, source, '--output', tmp.name, '--yes']
         with TemporaryFile(mode='w') as fake_write_obj:


### PR DESCRIPTION
Hi again. I just realized an issue on adding dependencies to **elm-package.json**: `elm-make` doesn't update the downloaded packages. It only complains about those missing:

```
Failed: elm: subprocess returned a non-success result code: 1, stdout=b'',
stderr=b'Could not find package JeremyBellows/elm-bootstrapify.\r\n\r\nMaybe your elm-stuff/ directory has been corrupted? You can usually fix stuff\r\nlike this by deleting elm-stuff/ and rebuilding your project.\r\n'
```

So you really have to either delete **elm-stuff/** or run `elm-package install` manually. Wouldn't it be better to do the latter automatically before `elm-make`? I added this.

The explicit `encoding='utf-8'` for `TemporaryFile` is for Windows compatibility. The missing `encoding=` also causes problems when `elm-make` downloads the packages:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u25cf' in position 29: character maps to <undefined>
```

It's because of those bullet point symbols in the output. When running `elm-package` before, this doesn't need to be handled for `elm-make` anymore.

Despite doing Windows compatibility stuff here I didn't include #3. Just to keep things separated. So the PRs conflict with each other now. I will then rebase once/if one of them gets accepted.

BTW: Wouldn't it also be nice to see the package download output int the console? By just redirecting to `stdout` instead of temp file. Which unfortunately needs some extra special handling on Windows again :)

CC @sils 
