### PR TITLE
Added option for switching to the source directory for compilation.

### DIFF
--- a/webassets_elm/__init__.py
+++ b/webassets_elm/__init__.py
@@ -1,9 +1,22 @@
-from os import remove
+from contextlib import contextmanager
+from os import chdir, getcwd, remove
+import os.path
 from sys import platform
 from tempfile import NamedTemporaryFile, TemporaryFile
 from webassets.filter import ExternalTool
 
 __all__ = ('Elm')
+
+
+@contextmanager
+def excursion(directory):
+    """Context-manager that temporarily changes to a new working directory."""
+    old_dir = getcwd()
+    try:
+        chdir(directory)
+        yield
+    finally:
+        chdir(old_dir)
 
 
 class Elm(ExternalTool):
@@ -20,7 +33,8 @@ class Elm(ExternalTool):
     """
 
     name = 'elm'
-    options = {'binary': 'ELM_MAKE_BIN'}
+    options = {'binary': 'ELM_MAKE_BIN',
+               'change_directory': 'ELM_MAKE_CHANGE_DIRECTORY'}
     max_debug_level = None
 
     def input(self, _in, out, **kw):
@@ -30,16 +44,19 @@ class Elm(ExternalTool):
         the compiled contents to a temporary file and then read it in order to
         output to stdout.
         """
-
         # create a temp file
         tmp = NamedTemporaryFile(suffix='.js', delete=False)
         tmp.close()  # close it so windows can read it
 
         # write to a temp file
         elm_make = self.binary or 'elm-make'
+        change_directory = bool(self.change_directory or False)
         source = kw['source_path']
+        source_dir = os.path.join(*os.path.split(source)[:-1])
+        exec_dir = source_dir if change_directory else getcwd()
         write_args = [elm_make, source, '--output', tmp.name, '--yes']
-        with TemporaryFile(mode='w') as fake_write_obj:
+        with excursion(exec_dir), \
+             TemporaryFile(mode='w') as fake_write_obj:
             self.subprocess(write_args, fake_write_obj)
 
         # read the temp file


### PR DESCRIPTION
This makes it easier to colocate elm-package.json files with the code trees that
they belong to. This option is false by default, preserving the original behavior.